### PR TITLE
将`get_group_member_list`中的`card`字段的默认值改为`nick`

### DIFF
--- a/handlers/get_group_member_list.go
+++ b/handlers/get_group_member_list.go
@@ -302,7 +302,7 @@ func GetGroupMemberList(client callapi.Client, api openapi.OpenAPI, apiv2 openap
 				UserID:          userIDUInt,
 				GroupID:         uint64(groupIDInt),
 				Nickname:        memberFromAPI.Nick,
-				Card:            "主人", // 使用默认值
+				Card:            memberFromAPI.Nick, // 使用昵称作为默认值(TODO: 将来可能发生变更)
 				Sex:             "0",  // 使用默认值
 				Age:             0,    // 使用默认值
 				Area:            "0",  // 使用默认值


### PR DESCRIPTION
将`get_group_member_list`中的`card`字段的默认值改为`nick`，以适应将`card`作为昵称使用的项目。做出此更改原因是目前官方接口能获取的昵称只有一种，`card`已经作为群名片已经失去意义。