### PR TITLE
启动SSL之后的备用HTTP端口可自定义

### DIFF
--- a/main.go
+++ b/main.go
@@ -567,18 +567,18 @@ func main() {
 		}
 	}()
 
-	// 如果主服务器使用443端口，同时在一个新的goroutine中启动444端口的HTTP服务器 todo 更优解
-	if serverPort == "443" {
+	// 如果主服务器使用443端口或conf.Settings.ForceSSL为true，同时在一个新的goroutine中启动conf.Settings.HttpPortAfterSSL端口的HTTP服务器
+	if serverPort == "443" || conf.Settings.ForceSSL {
 		go func() {
-			// 创建另一个http.Server实例（用于444端口）
-			httpServer444 := &http.Server{
-				Addr:    "0.0.0.0:444",
+			// 创建另一个http.Server实例（用于conf.Settings.HttpPortAfterSSL端口）
+			httpServerHttpPortAfterSSL := &http.Server{
+				Addr:    "0.0.0.0:" + conf.Settings.HttpPortAfterSSL,
 				Handler: r,
 			}
 
-			// 启动444端口的HTTP服务器
-			if err := httpServer444.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-				log.Fatalf("listen (HTTP 444): %s\n", err)
+			// 启动conf.Settings.HttpPortAfterSSL端口的HTTP服务器
+			if err := httpServerHttpPortAfterSSL.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+				log.Fatalf("listen (HTTP %s): %s\n", conf.Settings.HttpPortAfterSSL, err)
 			}
 		}()
 	}

--- a/structs/structs.go
+++ b/structs/structs.go
@@ -73,6 +73,7 @@ type Settings struct {
 	WebhookPath     string   `yaml:"webhook_path"`
 	WebhookPrefixIp []string `yaml:"webhook_prefix_ip"`
 	ForceSSL        bool     `yaml:"force_ssl"`
+	HttpPortAfterSSL string  `yaml:"http_port_after_ssl"`
 	//日志类
 	DeveloperLog     bool `yaml:"developer_log"`
 	LogLevel         int  `yaml:"log_level"`

--- a/template/config_template.go
+++ b/template/config_template.go
@@ -88,6 +88,7 @@ settings:
   webhook_path : "webhook"           #webhook监听的地址,默认\webhook
   webhook_prefix_ip : []             #默认为空,通过webhook进行签名验证来源,设置时,只允许ip前缀的请求,不验证签名. 2024年11月22日最近的webhookip都是 183.47.105. 开始的.
   force_ssl : false                  #默认当port设置为443时启用ssl,true可以在其他port设置下强制启用ssl.
+  http_port_after_ssl : "444"       # 指定启动SSL之后的备用HTTP服务器的端口号，默认为444
   
   #日志类
   developer_log : false             #开启开发者日志 默认关闭


### PR DESCRIPTION
启动SSL之后的备用HTTP端口可自定义