### PR TITLE
新增 custom_url 自定义url选项

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1364,6 +1364,18 @@ func GetTransferUrl() bool {
 	return instance.Settings.TransferUrl
 }
 
+// 获取CustomDomain的值
+func GetCustomDomain() string {
+	mu.RLock()
+	defer mu.RUnlock()
+
+	if instance == nil {
+		fmt.Println("Warning: instance is nil when trying to GetCustomDomain value.")
+		return ""
+	}
+	return instance.Settings.CustomDomain
+}
+
 // 获取 HTTP 地址
 func GetHttpAddress() string {
 	mu.RLock()

--- a/config/config.go
+++ b/config/config.go
@@ -1365,7 +1365,7 @@ func GetTransferUrl() bool {
 }
 
 // 获取CustomDomain的值
-func GetCustomDomain() string {
+func GetCustomUrl() string {
 	mu.RLock()
 	defer mu.RUnlock()
 
@@ -1373,7 +1373,7 @@ func GetCustomDomain() string {
 		fmt.Println("Warning: instance is nil when trying to GetCustomDomain value.")
 		return ""
 	}
-	return instance.Settings.CustomDomain
+	return instance.Settings.CustomUrl
 }
 
 // 获取 HTTP 地址

--- a/handlers/message_parser.go
+++ b/handlers/message_parser.go
@@ -992,7 +992,11 @@ func transformMessageTextUrl(messageText string, message callapi.ActionMessage, 
 				// 自己是主节点
 				shortURL := url.GenerateShortURL(originalURL)
 				// 使用getBaseURL函数来获取baseUrl并与shortURL组合
-				return url.GetBaseURL() + "/url/" + shortURL
+				baseURL := url.GetBaseURL()
+				if customDomain := config.GetCustomDomain(); customDomain != "" {
+					baseURL = customDomain
+				}
+				return baseURL + "/url/" + shortURL
 			}
 		})
 	}

--- a/handlers/message_parser.go
+++ b/handlers/message_parser.go
@@ -988,15 +988,14 @@ func transformMessageTextUrl(messageText string, message callapi.ActionMessage, 
 				mylog.Printf("转换url:%v", originalURL)
 				shortURL := url.GenerateShortURL(originalURL)
 				return shortURL
+			} else if config.GetCustomUrl() != "" {
+				shortURL := url.GenerateShortURL(originalURL)
+				return url.GetCustomUrl() + "/url/" + shortURL
 			} else {
 				// 自己是主节点
 				shortURL := url.GenerateShortURL(originalURL)
 				// 使用getBaseURL函数来获取baseUrl并与shortURL组合
-				baseURL := url.GetBaseURL()
-				if customDomain := config.GetCustomDomain(); customDomain != "" {
-					baseURL = customDomain
-				}
-				return baseURL + "/url/" + shortURL
+				return url.GetBaseURL() + "/url/" + shortURL
 			}
 		})
 	}

--- a/structs/structs.go
+++ b/structs/structs.go
@@ -65,15 +65,15 @@ type Settings struct {
 	EnableWsServer bool   `yaml:"enable_ws_server"`
 	WsServerToken  string `yaml:"ws_server_token"`
 	//ssl和链接转换类
-	IdentifyFile    bool     `yaml:"identify_file"`
-	IdentifyAppids  []int64  `yaml:"identify_appids"`
-	Crt             string   `yaml:"crt"`
-	Key             string   `yaml:"key"`
-	UseSelfCrt      bool     `yaml:"use_self_crt"`
-	WebhookPath     string   `yaml:"webhook_path"`
-	WebhookPrefixIp []string `yaml:"webhook_prefix_ip"`
-	ForceSSL        bool     `yaml:"force_ssl"`
-	HttpPortAfterSSL string  `yaml:"http_port_after_ssl"`
+	IdentifyFile     bool     `yaml:"identify_file"`
+	IdentifyAppids   []int64  `yaml:"identify_appids"`
+	Crt              string   `yaml:"crt"`
+	Key              string   `yaml:"key"`
+	UseSelfCrt       bool     `yaml:"use_self_crt"`
+	WebhookPath      string   `yaml:"webhook_path"`
+	WebhookPrefixIp  []string `yaml:"webhook_prefix_ip"`
+	ForceSSL         bool     `yaml:"force_ssl"`
+	HttpPortAfterSSL string   `yaml:"http_port_after_ssl"`
 	//日志类
 	DeveloperLog     bool `yaml:"developer_log"`
 	LogLevel         int  `yaml:"log_level"`
@@ -137,11 +137,11 @@ type Settings struct {
 	StringOb11       bool `yaml:"string_ob11"`
 	StringAction     bool `yaml:"string_action"`
 	//url相关
-	VisibleIp    bool `yaml:"visible_ip"`
-	UrlToQrimage bool `yaml:"url_to_qrimage"`
-	QrSize       int  `yaml:"qr_size"`
-	TransferUrl  bool `yaml:"transfer_url"`
-	CustomDomain string  `yaml:"custom_domain"`
+	VisibleIp    bool   `yaml:"visible_ip"`
+	UrlToQrimage bool   `yaml:"url_to_qrimage"`
+	QrSize       int    `yaml:"qr_size"`
+	TransferUrl  bool   `yaml:"transfer_url"`
+	CustomUrl    string `yaml:"custom_url"`
 	//框架修改
 	Title   string `yaml:"title"`
 	FrpPort string `yaml:"frp_port"`

--- a/structs/structs.go
+++ b/structs/structs.go
@@ -141,6 +141,7 @@ type Settings struct {
 	UrlToQrimage bool `yaml:"url_to_qrimage"`
 	QrSize       int  `yaml:"qr_size"`
 	TransferUrl  bool `yaml:"transfer_url"`
+	CustomDomain string  `yaml:"custom_domain"`
 	//框架修改
 	Title   string `yaml:"title"`
 	FrpPort string `yaml:"frp_port"`

--- a/template/config_template.go
+++ b/template/config_template.go
@@ -176,6 +176,7 @@ settings:
   url_to_qrimage : false            #将信息中的url转换为二维码单独作为图片发出,需要同时设置  #SSL配置类 机器人发送URL设置 的 transfer_url 为 true visible_ip也需要为true
   qr_size : 200                     #二维码尺寸,单位像素
   transfer_url : true                #默认开启,关闭后自理url发送,配置server_dir为你的域名,配置crt和key后,将域名/url和/image在q.qq.com后台通过校验,自动使用302跳转处理机器人发出的所有域名.
+  custom_url : ""                   #自定义url,当你的port设置为非443端口，又需要转换url时，可以设置此项，使用反代等手段将url转发到qq机器人服务器
 
   #框架修改
   title : "Gensokyo © 2023 - Hoshinonyaruko"              #程序的标题 如果多个机器人 可根据标题区分

--- a/url/shorturl.go
+++ b/url/shorturl.go
@@ -126,7 +126,7 @@ func GenerateShortURL(longURL string) string {
 	// 根据portValue确定协议
 	protocol := "http"
 	portValue := config.GetPortValue()
-	if portValue == "443" ||config.GetForceSsl(){
+	if portValue == "443" || config.GetForceSsl() {
 		protocol = "https"
 	}
 
@@ -242,7 +242,7 @@ func getLongURLFromDB(shortURL string) (string, error) {
 	// 根据portValue确定协议
 	protocol := "http"
 	portValue := config.GetPortValue()
-	if portValue == "443" ||config.GetForceSsl(){
+	if portValue == "443" || config.GetForceSsl() {
 		protocol = "https"
 	}
 
@@ -359,6 +359,12 @@ func isValidToken(token string) bool {
 func GetBaseURL() string {
 	serverDir := config.GetServer_dir()
 	return "https://" + serverDir
+}
+
+// 自定义短链接url
+func GetCustomUrl() string {
+	customUrl := config.GetCustomUrl()
+	return "https://" + customUrl
 }
 
 // RedirectFromShortURLHandler


### PR DESCRIPTION
当开发者无法使用443端口，而使用类似8443端口，webhook连接QQBot服务器，此时无法发出链接，因为443端口不可用，此 PR 新增了一个参数 custom_url , 开发者可以用另一个域名反向代理gsk的http_port_after_ssl端口，只反代url目录，这样就可以实现用另一个域名发链接了